### PR TITLE
roll back jquery version, remove bootstrap-hover-dropdown dependency,…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,9 +18,8 @@
     "README.md"
   ],
   "dependencies": {
-    "jquery": "2.2.4",
+    "jquery": "1.11.2",
     "jquery-touch-events": "1.0.5",
-    "bootstrap-hover-dropdown": "2.2.1",
     "bootstrap-sass": "3.3.6"
   }
 }

--- a/utk/js/citm.js
+++ b/utk/js/citm.js
@@ -2,7 +2,6 @@
 
 //=include ../../bower_components/jquery/dist/jquery.js
 //=include ../../bower_components/jquery-touch-events/src/jquery.mobile-events.js
-//=include ../../bower_components/bootstrap-hover-dropdown/bootstrap-hover-dropdown.js
 //=include ../../bower_components/bootstrap-sass/assets/javascripts/bootstrap.js
 
 //=include ./debug.js
@@ -16,5 +15,11 @@ $(document).ready(function() {
     $(".carousel").swipeleft(function() {  
         $(this).carousel('next');
     });
+    
+    // Toggle the navigation dropdowns on hover and click, still allowing for tap open on mobile
+    $('.dropdown').on('mouseenter mouseleave click', function() {
+        $(this).toggleClass("open");
+    });
+
 
 }); /* END document ready */


### PR DESCRIPTION
… add simple js to allow for hover-activated dropdowns that still function on mobile tap
